### PR TITLE
Fix the "! I can't find file `tkz-obj-angles.tex'." error which occur…

### DIFF
--- a/src/imgs/drawings/ambush/map_ambushed_drawing.tex
+++ b/src/imgs/drawings/ambush/map_ambushed_drawing.tex
@@ -1,7 +1,6 @@
 \documentclass[crop,tikz,ifthenelse]{standalone}% 'crop' is the default for v1.0, before it was 'preview'
 %\usetikzlibrary{...}% tikz package already loaded by 'tikz' option
 
-\usetkzobj{all}
 \begin{document}
 \begin{tikzpicture}[]
 

--- a/src/imgs/drawings/casting_a_ray/fixed.tex
+++ b/src/imgs/drawings/casting_a_ray/fixed.tex
@@ -1,6 +1,5 @@
 \documentclass[tikz,border=2pt,png]{standalone}
 \usepackage{tkz-euclide}
-\usetkzobj{all}
 \begin{document}
 \begin{tikzpicture}[scale=2.5]
 

--- a/src/imgs/drawings/casting_a_ray/situation.tex
+++ b/src/imgs/drawings/casting_a_ray/situation.tex
@@ -1,6 +1,5 @@
 \documentclass[tikz,border=2pt,png]{standalone}
 \usepackage{tkz-euclide}
-\usetkzobj{all}
 \begin{document}
 \begin{tikzpicture}[scale=2.5]
 

--- a/src/imgs/drawings/casting_a_ray/unaligned.tex
+++ b/src/imgs/drawings/casting_a_ray/unaligned.tex
@@ -1,6 +1,5 @@
 \documentclass[tikz,border=2pt,png]{standalone}
 \usepackage{tkz-euclide}
-\usetkzobj{all}
 \begin{document}
 \begin{tikzpicture}[scale=2.5]
 

--- a/src/imgs/drawings/dda.tex
+++ b/src/imgs/drawings/dda.tex
@@ -1,7 +1,6 @@
 \documentclass[tikz]{standalone}
 \usepackage{tikz}
 \usepackage{tkz-euclide}
-\usetkzobj{all}
 
 \usetikzlibrary{calc}
 \begin{document}

--- a/src/imgs/drawings/fish_eye/correct_way.tex
+++ b/src/imgs/drawings/fish_eye/correct_way.tex
@@ -1,6 +1,5 @@
 %\documentclass[tikz,border=2pt,png]{standalone}
 %\usepackage{tkz-euclide}
-\usetkzobj{all}
 %\begin{document}
 \begin{tikzpicture}[scale=2.0]
 

--- a/src/imgs/drawings/fish_eye/d_vs_z.tex
+++ b/src/imgs/drawings/fish_eye/d_vs_z.tex
@@ -1,6 +1,5 @@
 %\documentclass[tikz,border=2pt,png]{standalone}
 %\usepackage{tkz-euclide}
-%\usetkzobj{all}
 %\begin{document}
 \begin{tikzpicture}[scale=2.0]
 

--- a/src/imgs/drawings/fish_eye/state.tex
+++ b/src/imgs/drawings/fish_eye/state.tex
@@ -1,6 +1,5 @@
 %\documentclass[tikz,border=2pt,png]{standalone}
 %\usepackage{tkz-euclide}
-%\usetkzobj{all}
 %\begin{document}
 \begin{tikzpicture}[scale=1.3]
 

--- a/src/imgs/drawings/fish_eye/top_view_close.tex
+++ b/src/imgs/drawings/fish_eye/top_view_close.tex
@@ -1,7 +1,6 @@
 \documentclass[tikz,border=2pt,png]{standalone}
 \usepackage{tkz-euclide}
 \usetikzlibrary{intersections,decorations.markings}
-\usetkzobj{all}
 \begin{document}
 \begin{tikzpicture}[scale=2.0]
 

--- a/src/imgs/drawings/fish_eye/top_view_far.tex
+++ b/src/imgs/drawings/fish_eye/top_view_far.tex
@@ -1,7 +1,6 @@
 \documentclass[tikz,border=2pt,png]{standalone}
 \usepackage{tkz-euclide}
 \usetikzlibrary{intersections,decorations.markings}
-\usetkzobj{all}
 \begin{document}
 \begin{tikzpicture}[scale=2.0]
 

--- a/src/imgs/drawings/fish_eye/top_view_middle.tex
+++ b/src/imgs/drawings/fish_eye/top_view_middle.tex
@@ -1,7 +1,6 @@
 \documentclass[tikz,border=2pt,png]{standalone}
 \usepackage{tkz-euclide}
 \usetikzlibrary{intersections,decorations.markings}
-\usetkzobj{all}
 \begin{document}
 \begin{tikzpicture}[scale=2.0]
 

--- a/src/imgs/drawings/soh-cah-toa.tex
+++ b/src/imgs/drawings/soh-cah-toa.tex
@@ -2,7 +2,6 @@
 % \usepackage[x11names,dvipsnames]{xcolor} %Colocação de cores
 % \usepackage{tikz,tikz-3dplot} %Para fazer desenhos
 % \usepackage{tkz-euclide}
-% \usetkzobj{all}
 \begin{tikzpicture}[scale=1.5]
 
 % \begin{document}

--- a/src/imgs/drawings/unit_circle.tex
+++ b/src/imgs/drawings/unit_circle.tex
@@ -2,7 +2,6 @@
 
 % \usetikzlibrary{calc}
 % \usepackage{tkz-euclide}
-% \usetkzobj{all}
 
 
 % \begin{document}

--- a/src/mystyle.sty
+++ b/src/mystyle.sty
@@ -103,7 +103,6 @@
 \usetikzlibrary{calc}
 \usetikzlibrary{shadows} %include images can get a nice drop shadow
 \usepackage{tkz-euclide}
-\usetkzobj{all}
 \usepackage{fancyvrb}
 \usepackage{relsize}
 


### PR DESCRIPTION
With the 3.0x version `\usetkzobjall` is not needed anymore. I had to remove it to make `make.sh` succesfully generate the PDF document.

See:
- https://tex.stackexchange.com/questions/529550/latex-cant-find-file-tkz-obj-angles-tex/529562
- Section 1.6.1 of https://mirror.koddos.net/CTAN/macros/latex/contrib/tkz/tkz-euclide/doc/TKZdoc-euclide.pdf