### PR TITLE
fix misused println function in the build.go

### DIFF
--- a/build.go
+++ b/build.go
@@ -139,7 +139,7 @@ func makeCover(src string, dst string) {
 
 	output, err := exec.Command(bin, args...).CombinedOutput()
 	if err != nil {
-		fmt.Println("%s %s", string(output), err)
+		fmt.Println(string(output), err)
 		return
 	}
 }
@@ -211,7 +211,7 @@ func main() {
 	}
 
 	if err != nil {
-		fmt.Println("%s %s", string(out), err)
+		fmt.Println(string(out), err)
 	}
 
 	// Rename


### PR DESCRIPTION
fixes misused println function

from
```go
fmt.Println("%s %s", string(output), err)
```` 
to
```go
fmt.Println(string(output), err)
```