### PR TITLE
fix remove deprecated io functions

### DIFF
--- a/build.go
+++ b/build.go
@@ -3,12 +3,11 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+  "path"
+  "os"
+  "os/exec"
 	"strings"
 )
-import "os"
-import "os/exec"
-import "path"
 
 var inkscapeBin = "inkscape"
 var epsToPdfBin = "epstopdf"
@@ -61,7 +60,7 @@ func cwd() string {
 }
 
 func convertEPStoPDF(folder string) {
-	items, _ := ioutil.ReadDir(folder)
+	items, _ := os.ReadDir(folder)
 	for _, item := range items {
 		if item.IsDir() {
 			convertEPStoPDF(folder + item.Name() + "/")
@@ -84,7 +83,7 @@ func convertEPStoPDF(folder string) {
 }
 
 func convertSVGtoPNG(folder string) {
-	items, _ := ioutil.ReadDir(folder)
+	items, _ := os.ReadDir(folder)
 	for _, item := range items {
 		if item.IsDir() {
 			println("Directories in ", folder, " are not supported")


### PR DESCRIPTION
fixes: remove deprecated io functions

[ioutils is deprecated in go latest version before 16.](https://go.dev/doc/go1.16#ioutil)