### PR TITLE
Add Docker compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use the official Ubuntu base image
+FROM ubuntu:latest
+
+# Set the working directory inside the container
+WORKDIR /workspace
+
+# Update and install required packages
+RUN apt-get update && \
+    apt-get install -y \
+    inkscape \
+    texlive \
+    texlive-font-utils \
+    texlive-fonts-recommended \
+    texlive-latex-extra \
+    golang-go && \
+    # Clean up the apt cache to reduce image size
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /book
+VOLUME ["/book"]
+
+# Set default command
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ To compile on Windows:
  - Clone the repository inside the WSL environment. Cloning from Windows directly can cause issues due to CRLF line endings, which can prevent successful compilation.
  - Follow Linux instructions. 
 
+To compile on Docker:
+ - Run:
+    - `docker build -t gebb .`
+    - `docker run --rm -i -v "$PWD":/book gebb bash ./make.sh`
+
 To speed up compilation:
  - Build with `./make.sh debug` (uses 100 DPI assets)
  - Comment out the part you are not working on in src/book.tex


### PR DESCRIPTION
Added Docker compilation for portability and ease of use.

- Added Dockerfile for building the compilation environment.
- Updated README with Docker usage instructions.

Also works for other OCI-compliant engines like Podman by changing "docker" to the preferred engine.
