### PR TITLE
Updated Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ To compile on Mac OS X:
  - Install golang: https://go.dev/
  - Install Inkscape (min v1.0.0):
     - via installer: https://inkscape.org/download/
-    - or via Homebrew: `brew cask install xquartz inkscape`
+    - or via Homebrew: `brew install --cask xquartz inkscape`
  - Install MacTeX library (for epstopdf and pdflatex):
     - via installer: https://tug.org/mactex/mactex-download.html
-    - or via Homebrew, with GUI:    `brew cask install mactex`
-    - or via Homebrew, without GUI: `brew cask install mactex-no-gui`
+    - or via Homebrew, with GUI:    `brew install --cask mactex`
+    - or via Homebrew, without GUI: `brew install --cask mactex-no-gui`
  - Make sure inkscape binary is in your PATH or symlink it where your PATH points to.      
  - Run:
     - `./make.sh`


### PR DESCRIPTION
brew cask is no longer a supported command