### PR TITLE
move assumption to correct place

### DIFF
--- a/src/tricks.tex
+++ b/src/tricks.tex
@@ -127,7 +127,7 @@ There is an alternate way to represent a LFSR called "Galois", which allows one 
       
 \bu{Note :} Because the effect works by plotting pixels individually, it was hard to replicate when developers tried to port the game to hardware accelerated GPU. None of the ports managed to replicate the fizzlefade except Wolf4SDL, which even found maximum-length LFSR tap configurations to reach resolution higher than 320x200.\\
 \par
-\bu{Note :} The tap configuration on 17 bits generates 131,072 values before cycling. Since 320x200=64,000, it could have been implemented with a 16-bit Maximum-length register with taps on 16,15,13 and 4 (in "Galois" notation).
+\bu{Note :} The tap configuration on 17 bits generates 131,072 values before cycling. Since 320x200=64,000, it could have been implemented with a 16-bit Maximum-length register with taps on 16,15,13 and 4 (in "Galois" notation). My assumption is that LFSR literature was hard to find at the time and finding the correct tap for a 16-bit maximum length register was not worth the effort.
 
 
 
@@ -190,7 +190,7 @@ The random number generator saves the last index in \cw{rndindex}. Upon request 
 \lstinputlisting[ language={[x86masm]Assembler}]{code/US_RndT.asm}
 \end{minipage}
 
-This pseudo random series of 256 values could have been generated with an 8-bit Maximum length LFSR (8,6,5,4). My assumption is that LFSR literature was hard to find at the time and finding the correct tap for a 16-bit maximum length register was not worth the effort.\\
+This pseudo random series of 256 values could have been generated with an 8-bit Maximum length LFSR (8,6,5,4).\\
 
 
 


### PR DESCRIPTION
The line about assumptions involving 16-bit LFSR seems to be in the wrong place.